### PR TITLE
RoleRecycle was still being initiated on removal of dynamic hosted endpoint from storage

### DIFF
--- a/src/NServiceBus.Hosting.Azure/DynamicHost/DynamicEndpointRunner.cs
+++ b/src/NServiceBus.Hosting.Azure/DynamicHost/DynamicEndpointRunner.cs
@@ -51,12 +51,7 @@ namespace NServiceBus.Hosting.Azure
                     process.Exited += (o, args) =>
                     {
                         bool trash;
-                        var wasInList = StoppedProcessIds.TryRemove(process.Id, out trash);
-                        //unhook the errorDataHandler so that it does not fire and cause a recycle.
-                        if(wasInList)
-                        {
-                            processWasKilledOnPurpose = true;
-                        }
+                        processWasKilledOnPurpose = StoppedProcessIds.TryRemove(process.Id, out trash);
                         if (process.ExitCode != 0 && !processWasKilledOnPurpose)
                         {
                             if (RecycleRoleOnError) SafeRoleEnvironment.RequestRecycle();


### PR DESCRIPTION
In DynamicEndpointRunner:
Despite the Process.Exited event being fired and run, the ErrorDataReceived was still executing.

In repeated tests the order of execution appears to be consistent
Process.Exited occurs and delegate is executed
Process.ErrorDataReceived occurs and delegate is executed.

When the Kill method is called on a process,  it reliably executes in that order.  Therefore we set a flag on the endpoint instance in the Exited handler indicated it was shutdown on purpose. We then check  that flag in ErrorDataReceived before allowing the Recycle request to fire.

I acknowledge that I am unsure that there is not a condition that pops ErrorDataReceived BEFORE Exited, but I was not able to cause that to occur.