### PR TITLE
DefineEndpointName allows to override the host assigned endpoint name

### DIFF
--- a/src/NServiceBus.Hosting.Azure.Tests/APIApprovals.Approve.approved.txt
+++ b/src/NServiceBus.Hosting.Azure.Tests/APIApprovals.Approve.approved.txt
@@ -18,6 +18,10 @@ namespace NServiceBus
     }
     public class static EndpointConfigurationExtensions
     {
+        public static void DefineEndpointName(this NServiceBus.EndpointConfiguration configuration, string endpointName) { }
+    }
+    public class static EndpointStartableAndStoppableExtensions
+    {
         public static void RunWhenEndpointStartsAndStops(this NServiceBus.EndpointConfiguration configuration, NServiceBus.IWantToRunWhenEndpointStartsAndStops startableAndStoppable) { }
     }
     public class HostingSettings

--- a/src/NServiceBus.Hosting.Azure/EndpointConfigurationExtensions.cs
+++ b/src/NServiceBus.Hosting.Azure/EndpointConfigurationExtensions.cs
@@ -1,0 +1,20 @@
+﻿namespace NServiceBus
+{
+    using Configuration.AdvanceExtensibility;
+
+    /// <summary>
+    /// Extentions for <see cref="EndpointConfiguration"/>.
+    /// </summary>
+    public static class EndpointConfigurationExtensions
+    {
+        /// <summary>
+        /// Defines the endpoint name in code thus overriding the previously assigned endpoint name.
+        /// </summary>
+        /// <param name="configuration">The configuration.</param>
+        /// <param name="endpointName">The endpoint name to be used.</param>
+        public static void DefineEndpointName(this EndpointConfiguration configuration, string endpointName)
+        {
+            configuration.GetSettings().Set("NServiceBus.Routing.EndpointName", endpointName);
+        }
+    }
+}

--- a/src/NServiceBus.Hosting.Azure/NServiceBus.Hosting.Azure.csproj
+++ b/src/NServiceBus.Hosting.Azure/NServiceBus.Hosting.Azure.csproj
@@ -113,6 +113,7 @@
     <Compile Include="DynamicHost\DynamicHostMonitor.cs" />
     <Compile Include="DynamicHost\EndpointsEventArgs.cs" />
     <Compile Include="DynamicHost\EndpointToHost.cs" />
+    <Compile Include="EndpointConfigurationExtensions.cs" />
     <Compile Include="FileVersionRetriever.cs" />
     <Compile Include="GenericHost.cs" />
     <Compile Include="IConfigureThisEndpoint.cs" />
@@ -134,7 +135,7 @@
     <Compile Include="Roles\AsA_Host.cs" />
     <Compile Include="Roles\AsA_Worker.cs" />
     <Compile Include="Roles\UsingTransport.cs" />
-    <Compile Include="StartableAndStoppable\EndpointConfigurationExtensions.cs" />
+    <Compile Include="StartableAndStoppable\EndpointStartableAndStoppableExtensions.cs" />
     <Compile Include="StartableAndStoppable\IWantToRunWhenEndpointStartsAndStops.cs" />
     <Compile Include="StartableAndStoppable\StartableAndStoppableFeature.cs" />
     <Compile Include="StartableAndStoppable\StartableAndStoppableRunner.cs" />

--- a/src/NServiceBus.Hosting.Azure/StartableAndStoppable/EndpointStartableAndStoppableExtensions.cs
+++ b/src/NServiceBus.Hosting.Azure/StartableAndStoppable/EndpointStartableAndStoppableExtensions.cs
@@ -4,9 +4,9 @@ namespace NServiceBus
     using Configuration.AdvanceExtensibility;
 
     /// <summary>
-    /// Extension methods for EndpointConfiguration
+    /// Extension methods for EndpointConfiguration.
     /// </summary>
-    public static class EndpointConfigurationExtensions
+    public static class EndpointStartableAndStoppableExtensions
     {
         /// <summary>
         /// Register a specific instance of an IWantToRunWhenEndpointStartsAndStops implementation


### PR DESCRIPTION
Relates to https://github.com/Particular/NServiceBus.Host.AzureCloudService/issues/57

Re-enables the possibility override the endpoint name from code.

-  Called it `DefineEndpointName` because Core has an obsoleted `EndpointName` method on the `EndpointConfiguration` level.

Docs PR 

https://github.com/Particular/docs.particular.net/pull/1657

@Particular/nservicebus-maintainers please review and merge

