### PR TITLE
Use the types returned from the scanner instead

### DIFF
--- a/src/NServiceBus.Host.AzureCloudService.sln.DotSettings
+++ b/src/NServiceBus.Host.AzureCloudService.sln.DotSettings
@@ -592,6 +592,7 @@ II.2.12 &lt;HandlesEvent /&gt;&#xD;
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateBlankLinesAroundFieldToBlankLinesAroundProperty/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateThisQualifierSettings/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002EJavaScript_002ECodeStyle_002ESettingsUpgrade_002EJsCodeFormatterSettingsUpgrader/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002EJavaScript_002ECodeStyle_002ESettingsUpgrade_002EJsParsFormattingSettingsUpgrader/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002EJavaScript_002ECodeStyle_002ESettingsUpgrade_002EJsWrapperSettingsUpgrader/@EntryIndexedValue">True</s:Boolean>
 	
 	

--- a/src/NServiceBus.Hosting.Azure.HostProcess/Program.cs
+++ b/src/NServiceBus.Hosting.Azure.HostProcess/Program.cs
@@ -29,7 +29,7 @@
             settings.ConfigurationFile = endpointConfigurationFile;
             var domain = AppDomain.CreateDomain(endpointId, null, settings);
             var windowsHost = domain.CreateInstanceAndUnwrap<WindowsHost>(endpointConfigurationType);
-            
+
             windowsHost.Start();
 
             WaitHandle.WaitAny(new WaitHandle[]
@@ -75,13 +75,12 @@
                 ThrowExceptions = false
             };
 
-            var scannedAssemblies = assemblyScanner.GetScannableAssemblies().Assemblies;
-            
-            return scannedAssemblies
-                .SelectMany(assembly => assembly.GetTypes().Where(
+            var scanResult = assemblyScanner.GetScannableAssemblies();
+
+            return scanResult.Types.Where(
                 t => typeof(IConfigureThisEndpoint).IsAssignableFrom(t)
                      && t != typeof(IConfigureThisEndpoint)
-                     && !t.IsAbstract)).ToList();
+                     && !t.IsAbstract).ToList();
         }
 
         static void ValidateEndpoints(IList<Type> endpointConfigurationTypes)

--- a/src/NServiceBus.Hosting.Azure/RoleHost/Entrypoint.cs
+++ b/src/NServiceBus.Hosting.Azure/RoleHost/Entrypoint.cs
@@ -97,13 +97,12 @@ namespace NServiceBus
                 ThrowExceptions = false
             };
 
-            var scannedAssemblies = assemblyScanner.GetScannableAssemblies().Assemblies;
-            
-            return scannedAssemblies.SelectMany(
-                assembly => assembly.GetTypes().Where(
+            var scanResult = assemblyScanner.GetScannableAssemblies();
+
+            return scanResult.Types.Where(
                     t => typeof(IConfigureThisEndpoint).IsAssignableFrom(t)
                          && t != typeof(IConfigureThisEndpoint)
-                         && !t.IsAbstract));
+                         && !t.IsAbstract);
         }
 
         static void ValidateEndpoints(IList<Type> endpointConfigurationTypes)


### PR DESCRIPTION
Since NServiceBus core Version 6 now can return partially scannable assemblies the host will blow up since it does its own `.GetTypes()` call on each assembly in order to find the class implementing `IConfigureThisEndpoint`.

### Symptoms

The Version 7 host blows up during startup if there is a assembly that is partially scannable. This forces the users to add assembly redirects to both `NServiceBus.Host.exe.config` and `app.config`

### Who's affected

All version 7 users.

### Workaround

Add a `NServiceBus.Host.exe.config` file with the same redirects as the app.config

This fixes the same issue as we had with the windows host https://github.com/Particular/NServiceBus.Host/issues/115

@Particular/azure-maintainers please review