### PR TITLE
Hotfix 7.1.1

### DIFF
--- a/packaging/nuget/nservicebus.hosting.azure.hostprocess.nuspec
+++ b/packaging/nuget/nservicebus.hosting.azure.hostprocess.nuspec
@@ -16,7 +16,7 @@
     <dependencies>
       <dependency id="NServiceBus" version="[6.0.0, 7.0.0)" />
       <dependency id="NServiceBus.Hosting.Azure" version="[$version$, 8.0.0)" />
-      <dependency id="WindowsAzure.Storage" version="[8.0.0, 9.0.0)" />
+      <dependency id="WindowsAzure.Storage" version="[7.0.0, 9.0.0)" />
     </dependencies>
   </metadata>
   <files>

--- a/packaging/nuget/nservicebus.hosting.azure.nuspec
+++ b/packaging/nuget/nservicebus.hosting.azure.nuspec
@@ -15,7 +15,7 @@
     <tags>$tags$</tags>
     <dependencies>
       <dependency id="NServiceBus" version="[6.0.0, 7.0.0)" />
-      <dependency id="WindowsAzure.Storage" version="[8.0.0, 9.0.0)" />
+      <dependency id="WindowsAzure.Storage" version="[7.0.0, 9.0.0)" />
     </dependencies>
   </metadata>
   <files>


### PR DESCRIPTION
## Who's affected

* Any user using Azure Cloud Service hosting version 7.1.0

## Symptoms

Version 7.1.0 has forced to update [WindowsAzure.Storage](https://www.nuget.org/packages/WindowsAzure.Storage) package to version 8 while project(s) might need to stay on version 7.

## Changes

Extend Storage dependency range to support version 7 and up.