### PR TITLE
Hotfix 7.1.2

### DIFF
--- a/packaging/nuget/nservicebus.hosting.azure.hostprocess.nuspec
+++ b/packaging/nuget/nservicebus.hosting.azure.hostprocess.nuspec
@@ -16,7 +16,7 @@
     <dependencies>
       <dependency id="NServiceBus" version="[6.0.0, 7.0.0)" />
       <dependency id="NServiceBus.Hosting.Azure" version="[$version$, 8.0.0)" />
-      <dependency id="WindowsAzure.Storage" version="[7.0.0, 9.0.0)" />
+      <dependency id="WindowsAzure.Storage" version="[8.0.0, 9.0.0)" />
     </dependencies>
   </metadata>
   <files>

--- a/src/NServiceBus.Hosting.Azure.HostProcess/NServiceBus.Hosting.Azure.HostProcess.csproj
+++ b/src/NServiceBus.Hosting.Azure.HostProcess/NServiceBus.Hosting.Azure.HostProcess.csproj
@@ -62,8 +62,8 @@
       <HintPath>..\packages\Microsoft.Data.Services.Client.5.8.2\lib\net40\Microsoft.Data.Services.Client.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.WindowsAzure.Storage, Version=8.1.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\WindowsAzure.Storage.8.1.1\lib\net45\Microsoft.WindowsAzure.Storage.dll</HintPath>
+    <Reference Include="Microsoft.WindowsAzure.Storage, Version=8.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\WindowsAzure.Storage.8.0.0\lib\net45\Microsoft.WindowsAzure.Storage.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">

--- a/src/NServiceBus.Hosting.Azure.HostProcess/app.config
+++ b/src/NServiceBus.Hosting.Azure.HostProcess/app.config
@@ -4,15 +4,15 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Data.Edm" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-5.7.0.0" newVersion="5.7.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-5.8.1.0" newVersion="5.8.1.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Data.Services.Client" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-5.7.0.0" newVersion="5.7.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-5.8.1.0" newVersion="5.8.1.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Data.OData" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-5.7.0.0" newVersion="5.7.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-5.8.1.0" newVersion="5.8.1.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.WindowsAzure.Storage" publicKeyToken="31bf3856ad364e35" culture="neutral" />

--- a/src/NServiceBus.Hosting.Azure.HostProcess/packages.config
+++ b/src/NServiceBus.Hosting.Azure.HostProcess/packages.config
@@ -13,5 +13,5 @@
   <package id="System.Linq.Queryable" version="4.3.0" targetFramework="net452" />
   <package id="System.Net.Requests" version="4.3.0" targetFramework="net452" />
   <package id="System.Spatial" version="5.8.2" targetFramework="net452" />
-  <package id="WindowsAzure.Storage" version="8.1.1" targetFramework="net452" />
+  <package id="WindowsAzure.Storage" version="8.0.0" targetFramework="net452" />
 </packages>

--- a/src/NServiceBus.Hosting.Azure/NServiceBus.Hosting.Azure.csproj
+++ b/src/NServiceBus.Hosting.Azure/NServiceBus.Hosting.Azure.csproj
@@ -66,8 +66,8 @@
       <HintPath>..\packages\Microsoft.Data.Services.Client.5.8.2\lib\net40\Microsoft.Data.Services.Client.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.WindowsAzure.Storage, Version=8.1.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\WindowsAzure.Storage.8.1.1\lib\net45\Microsoft.WindowsAzure.Storage.dll</HintPath>
+    <Reference Include="Microsoft.WindowsAzure.Storage, Version=8.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\WindowsAzure.Storage.8.0.0\lib\net45\Microsoft.WindowsAzure.Storage.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">

--- a/src/NServiceBus.Hosting.Azure/app.config
+++ b/src/NServiceBus.Hosting.Azure/app.config
@@ -34,15 +34,15 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Data.Edm" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-5.7.0.0" newVersion="5.7.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-5.8.1.0" newVersion="5.8.1.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Data.Services.Client" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-5.7.0.0" newVersion="5.7.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-5.8.1.0" newVersion="5.8.1.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Data.OData" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-5.7.0.0" newVersion="5.7.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-5.8.1.0" newVersion="5.8.1.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Spatial" publicKeyToken="31bf3856ad364e35" culture="neutral" />

--- a/src/NServiceBus.Hosting.Azure/packages.config
+++ b/src/NServiceBus.Hosting.Azure/packages.config
@@ -15,5 +15,5 @@
   <package id="System.Linq.Queryable" version="4.3.0" targetFramework="net452" />
   <package id="System.Net.Requests" version="4.3.0" targetFramework="net452" />
   <package id="System.Spatial" version="5.8.2" targetFramework="net452" />
-  <package id="WindowsAzure.Storage" version="8.1.1" targetFramework="net452" />
+  <package id="WindowsAzure.Storage" version="8.0.0" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
## Who's affected

* Anyone using Azure Cloud Service hosting and require [`WindowsAzure.Storage`](https://www.nuget.org/packages/WindowsAzure.Storage) package to version 8 and later.

## Where are versions 7.1.0 and 7.1.1

Internal releases 7.1.0 and 7.1.1 were not made public and are deprecated by this release (7.1.2)

## Changes

- WindowsAzure.Storage dependency to be restricted to the major version 8
- Production targets `WindowsAzure.Storage` 8.0.0
- Test targets `WindowsAzure.Storage` the latest version of 8

### PoA
- [x] Bump up the storage library to 8
- [x]  Mark the appropriate PRs/issues with the milestone
- [x]  Create `hotfix-7.1.2`
- [x]  Smoke test doco/samples
- [ ] Merge to `master` and release to myget
- [ ] Merge back to `develop`
- [ ] Create doco PR
- [ ]  Release