### PR TITLE
Scan for IConfigureThisHost (#84)

### DIFF
--- a/src/NServiceBus.Hosting.Azure/RoleHost/Entrypoint.cs
+++ b/src/NServiceBus.Hosting.Azure/RoleHost/Entrypoint.cs
@@ -100,7 +100,7 @@ namespace NServiceBus
             var scanResult = assemblyScanner.GetScannableAssemblies();
 
             return scanResult.Types.Where(
-                    t => typeof(IConfigureThisEndpoint).IsAssignableFrom(t)
+                    t => (typeof(IConfigureThisEndpoint).IsAssignableFrom(t) || typeof(IConfigureThisHost).IsAssignableFrom(t))
                          && t != typeof(IConfigureThisEndpoint)
                          && !t.IsAbstract);
         }


### PR DESCRIPTION
According to the documentation page, it is only necessary to implement
the IConfigureThisHost interface for a shared host, not both
IConfigureThisEndpoint and IConfigureThisHost.  Modified the scanning
clause to allow for either interface implementation.

Connects to #84 