### PR TITLE
Shared Host cannot be configured without IConfigureThisEndpoint

### DIFF
--- a/src/NServiceBus.Hosting.Azure/RoleHost/Entrypoint.cs
+++ b/src/NServiceBus.Hosting.Azure/RoleHost/Entrypoint.cs
@@ -100,7 +100,7 @@ namespace NServiceBus
             var scanResult = assemblyScanner.GetScannableAssemblies();
 
             return scanResult.Types.Where(
-                    t => typeof(IConfigureThisEndpoint).IsAssignableFrom(t)
+                    t => (typeof(IConfigureThisEndpoint).IsAssignableFrom(t) || typeof(IConfigureThisHost).IsAssignableFrom(t))
                          && t != typeof(IConfigureThisEndpoint)
                          && !t.IsAbstract);
         }


### PR DESCRIPTION
Connects to #84

## Symptoms

After implementing only `IConfigureThisHost` the host does not start up as a dynamic host.

## Who's affected

All version 7 users that implement `IConfigureThisHost` without also implementing `IConfigureThisEndpoint`

## Workaround

Implementing `IConfigureThisEndpoint` in the same class as implementing `IConfigureThisHost` will allow the host to launch as a dynamic host.